### PR TITLE
Fix: don't JSON.stringify form-encoded data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerxstudio/node-common",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "description": "A set of MakerX core NodeJS types and utilities",
   "author": "MakerX",

--- a/src/http.ts
+++ b/src/http.ts
@@ -225,7 +225,7 @@ export async function makeHttpRequest({
       ...(contentType && { 'Content-Type': contentType }),
       ...(accept && { Accept: accept }),
     },
-    body: data ? JSON.stringify(data) : undefined,
+    body: data instanceof URLSearchParams ? data : data ? JSON.stringify(data) : undefined,
   }
 
   // strip sensitive request data for logging


### PR DESCRIPTION
- form-encoded contentType is set when `data instanceof URLSearchParams`
- fix is to not JSON.stringify the data when `data instanceof URLSearchParams`