### PR TITLE
Switch to being a CommonJS package

### DIFF
--- a/.tstoolkitrc.ts
+++ b/.tstoolkitrc.ts
@@ -1,14 +1,14 @@
-import type { TsToolkitConfig } from "@makerx/ts-toolkit";
+import type { TsToolkitConfig } from '@makerx/ts-toolkit'
 
 const config: TsToolkitConfig = {
   packageConfig: {
     srcDir: 'src',
     outDir: 'dist',
-    moduleType: 'module',
+    moduleType: 'commonjs',
     main: 'index.ts',
     exports: {
-      '.': 'index.ts'
-    }
-  }
+      '.': 'index.ts',
+    },
+  },
 }
 export default config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-common",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-common",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@makerx/eslint-config": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-common",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": false,
   "description": "A set of MakerX core NodeJS types and utilities",
   "author": "MakerX",


### PR DESCRIPTION
## What

This switches the package to be a CJS package instead of an ESM one.

## Why

The last version release, v1.4.1, caused issues in the projects it was installed in.

We tracked this back to <https://github.com/MakerXStudio/node-common/pull/139/files#diff-f5a14062aca0d6da6bf54b0da041653ba65ae53e7d63a39f1610aad323df6ffc> which made the shipped `package.json` to switch from `"type": "commonjs"` to `"type": "module"`, meaning tools will by default try to run them as ES modules.

I _think_ we could have kept `"type": "module"` and switch the CJS files to the `.cjs` extension, however ts-toolkit currently [emits `.js` extensions in the `package.json` file during transformation](https://github.com/MakerXStudio/ts-toolkit/blob/de55c0fccf5928f43cd014df39444f48fa23250a/src/util/copy-package-json-from-config.ts#L41-L55).

I tested this with `npm link` on two projects that failed and it solved my issues.