### PR TITLE
Fix the package file cjs entry reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "module": "index.mjs",
   "types": "index.d.ts",
-  "main": "index.cjs",
+  "main": "index.js",
   "engines": {
     "node": ">=18.0"
   },


### PR DESCRIPTION
## Note

The build is failing due to vulns being found in the audit step. PR #157 addresses this.

## Main

The output configuration using Rollup is

```ts
  output: [
    {
      dir: 'dist',
      format: 'cjs',
      entryFileNames: '[name].js',
      preserveModules: true,
      sourcemap: true,
      dynamicImportInCjs: false,
    },
    {
      dir: 'dist',
      format: 'es',
      entryFileNames: '[name].mjs',
      preserveModules: true,
      sourcemap: true,
    },
  ],
```

As you can see, ESM gets the `mjs` extension. However, CJS keeps the traditional `js` extension.

However, in the package file

```json
  "type": "module",
  "module": "index.mjs",
  "types": "index.d.ts",
  "main": "index.cjs",
```

you will notice the `main` import is referencing the `cjs` extension.